### PR TITLE
Upgrade Terraform and file_template usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.1.1 (Dec 1, 2015)
 
 #### FEATURES:
 * Added support for assigning Elastic IP address to each NAT instance.
@@ -7,6 +7,7 @@
 * Added support for VPC flow logs [GH-1]
 
 #### IMPROVEMENTS:
+* Updated template_file usage for 0.6.7 to remove deprecation warnings [GH-10]
 * Replaced user_data template and parameters with generic user_data param.
 
 ## 0.1.0 (Oct 21, 2015)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Module stack that supports full AWS VPC deployment.  Users can provision a basic
 * DHCP Options Set
 * Virtual Private Gateway creation
 
+## Requirements ##
+
+- Terraform 0.6.7 or newer
+- AWS provider
+
 ## Base Module ##
 
 The Base module provisions the VPC, attaches an Internet Gateway, and creates NAT Security Group, DMZ Routing table, and creates a CloudWatch group, IAM role, and AWS flow log.  The flow log is configured to capture all traffic (ALLOW and DENY) over the entire VPC.

--- a/az/main.tf
+++ b/az/main.tf
@@ -34,12 +34,12 @@ resource "aws_instance" "nat" {
   subnet_id = "${element(aws_subnet.dmz.*.id,count.index)}"
   source_dest_check = false
   user_data = "${var.user_data}"
+
   tags {
     Name = "${var.stack_item_label}-nat-${count.index}"
     application = "${var.stack_item_fullname}"
     managed_by = "terraform"
   }
-  user_data = "${element(template_file.user_data.*.rendered, count.index)}"
 }
 
 resource "aws_eip" "nat_eip" {

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
-    TF_VERSION: 0.6.6
-    TF_URL: https://dl.bintray.com/mitchellh/terraform/terraform_${TF_VERSION}_linux_amd64.zip
+    TF_VERSION: 0.6.7
+    TF_URL: https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
 dependencies:
   pre:
     - "[[ -f \"${HOME}/bin/terraform\" ]] || (wget -O \"/tmp/tf.zip\" \"${TF_URL}\" && unzip -o -d \"${HOME}/bin\" \"/tmp/tf.zip\")"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -19,7 +19,7 @@ module "vpc_base" {
 
 ## Generates instance user data from a template
 resource "template_file" "user_data" {
-  filename = "../templates/user_data.tpl"
+  template = "${file("../templates/user_data.tpl")}"
 
   vars {
     hostname = "${var.stack_item_label}-example"

--- a/examples/full_stack/main.tf
+++ b/examples/full_stack/main.tf
@@ -44,7 +44,7 @@ module "vpc_vpg" {
 
 ## Generates instance user data from a template
 resource "template_file" "user_data" {
-  filename = "../templates/user_data.tpl"
+  template = "${file("../templates/user_data.tpl")}"
 
   vars {
     hostname = "${var.stack_item_label}-example"


### PR DESCRIPTION
Updated usage of `file_template` resources to replace the deprecated `filename` parameter with the `template` parameter. Updated documentation and build for Terraform 0.6.7.
