### PR TITLE
Add CIDR blocks to AZ module output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+## 0.2.1 (May 16, 2016)
+
+#### FEATURES:
+* Exposed subnet CIDR blocks as AZ module outputs.
+
+#### IMPROVEMENTS:
+* Verified with Terraform v0.6.15.
+* Updated formatting to HashiCorp standard.
+* Expanded examples to include new VPC resources.
+
 ## 0.2.0 (Apr 20, 2016)
 
 #### FEATURES:
@@ -7,9 +17,7 @@
 * Added support for enabling ClassicLink.
 
 #### IMPROVEMENTS:
-* Verified with Terraform v0.6.15.
-* Updated formatting to HashiCorp standard.
-* Expanded examples to include new VPC resources.
+* Verified with Terraform v0.6.14.
 * Migrated NAT features to VPC NAT gateway.
 
 ## 0.1.1 (Dec 1, 2015)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ module "AZs" {
 
 - `lan_id` - List of subnet IDs of the LAN subnetworks.
 - `dmz_id` - List of subnet IDs of the DMZ subnetworks.
+- `lan_cidr` - List of subnet CIDR blocks of the LAN subnetworks.
+- `dmz_cidr` - List of subnet CIDR blocks of the DMZ subnetworks.
 - `eip_nat_id` - List of Elastic IP IDs for each of the NAT gateways.
 - `nat_id` - List of NAT gateways IDs.
 - `rt_lan_id` - List of routing table IDs for the LAN subnets.

--- a/az/outputs.tf
+++ b/az/outputs.tf
@@ -9,6 +9,15 @@ output "lan_id" {
   value = "${join(",",aws_subnet.lan.*.id)}"
 }
 
+## Returns Subnet CIDR blocks
+output "dmz_cidr" {
+  value = "${join(",",aws_subnet.dmz.*.cidr_block)}"
+}
+
+output "lan_cidr" {
+  value = "${join(",",aws_subnet.lan.*.cidr_block)}"
+}
+
 ## Returns information about the NATs
 output "eip_nat_id" {
   value = "${join(",",aws_eip.eip_nat.*.id)}"


### PR DESCRIPTION
Update to expose the subnet CIDR blocks as a module output.
