### PR TITLE
Verified against Terraform 0.7.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.tfstate*
 .terraform/
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
 
 gem "rake"
+gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,15 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    rake (10.4.2)
+    dotenv (2.1.1)
+    rake (11.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv
   rake
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,17 @@
 require 'rake'
+require 'dotenv'
 
-inputs = {
-  'stack_item_label'    => 'exmpl',
-  'stack_item_fullname' => 'Full Terraform AWS VPC deployment example',
-  'domain_name'         => 'unif.io',
-  'ami'                 => 'ami-xxxxxx',
-  'key_name'            => 'example',
-  'ssh_user'            => 'ec2-user',
-}
+Dotenv.load(".env")
 
 task :default => :verify
 
 desc "Verify the stack"
 task :verify do
 
-  vars = []
-  inputs.each() do |var, value|
-    vars.push("-var #{var}=\"#{value}\"")
-  end
-
   ['basic', 'full_stack'].each do |stack|
-    task_args = {:stack => stack, :args => vars.join(' ')}
+    task_args = {:stack => stack, :tf_img => ENV['TF_IMG'], :tf_cmd => ENV['TF_CMD']}
     Rake::Task['clean'].execute(Rake::TaskArguments.new(task_args.keys, task_args.values))
+    Rake::Task['check_style'].execute(Rake::TaskArguments.new(task_args.keys, task_args.values))
     Rake::Task['plan'].execute(Rake::TaskArguments.new(task_args.keys, task_args.values))
   end
 end
@@ -31,7 +21,12 @@ task :clean, [:stack] do |t, args|
   sh "cd examples/#{args['stack']} && rm -fr .terraform *.tfstate*"
 end
 
+desc "Check style"
+task :check_style, [:stack, :tf_img, :tf_cmd] do |t, args|
+  sh "[ $(#{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} fmt -write=false | wc -l) -eq 0 ]"
+end
+
 desc "Create execution plan"
-task :plan, [:stack, :args] do |t, args|
-  sh "cd examples/#{args['stack']} && terraform get && terraform plan -module-depth=-1 -input=false #{args['args']}"
+task :plan, [:stack, :tf_img, :tf_cmd] do |t, args|
+  sh "#{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} get && #{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} plan -module-depth=-1 -input=false -var-file /data/examples/#{args['stack']}.tfvars"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ task :verify do
     task_args = {:stack => stack, :tf_img => ENV['TF_IMG'], :tf_cmd => ENV['TF_CMD']}
     Rake::Task['clean'].execute(Rake::TaskArguments.new(task_args.keys, task_args.values))
     Rake::Task['check_style'].execute(Rake::TaskArguments.new(task_args.keys, task_args.values))
+    Rake::Task['get'].execute(Rake::TaskArguments.new(task_args.keys, task_args.values))
     Rake::Task['plan'].execute(Rake::TaskArguments.new(task_args.keys, task_args.values))
   end
 end
@@ -28,5 +29,20 @@ end
 
 desc "Create execution plan"
 task :plan, [:stack, :tf_img, :tf_cmd] do |t, args|
-  sh "#{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} get && #{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} plan -module-depth=-1 -input=false -var-file /data/examples/#{args['stack']}.tfvars"
+  sh "#{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} plan -module-depth=-1 -input=false -var-file /data/examples/#{args['stack']}.tfvars"
+end
+
+desc "Get modules"
+task :get, [:stack, :tf_img, :tf_cmd] do |t, args|
+  sh "#{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} get"
+end
+
+desc "Apply stack"
+task :apply, [:stack, :tf_img, :tf_cmd, :var_file] do |t, args|
+  sh "#{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} apply -var-file /data/examples/#{args['var_file']}"
+end
+
+desc "Destroy stack"
+task :destroy, [:stack, :tf_img, :tf_cmd, :var_file] do |t, args|
+  sh "#{args['tf_cmd']} -v `pwd`:/data -w /data/examples/#{args['stack']} #{args['tf_img']} destroy -force -var-file /data/examples/#{args['var_file']}"
 end

--- a/circle.yml
+++ b/circle.yml
@@ -1,14 +1,11 @@
 machine:
+  services:
+    - docker
   environment:
-    TF_VERSION: 0.6.16
-    TF_URL: https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
-dependencies:
-  pre:
-    - "[[ -f \"${HOME}/bin/terraform\" ]] || (wget -O \"/tmp/tf.zip\" \"${TF_URL}\" && unzip -o -d \"${HOME}/bin\" \"/tmp/tf.zip\")"
-    - terraform version
+    TF_IMG: unifio/terraform:0.7.4
+    TF_CMD: docker run -v /home/ubuntu/.aws:/home/user/.aws -e AWS_DEFAULT_REGION=us-east-1 -e LOCAL_USER_ID=1000 --rm
 test:
+  pre:
+    - docker pull $TF_IMG
   override:
-    # Style check
-    - "[ $(terraform fmt -write=false | wc -l) -eq 0 ]"
-    # Verify plan
     - bundle exec rake

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,5 @@ test:
     - docker pull $TF_IMG
   override:
     - bundle exec rake
+    - "bundle exec rake apply['basic',${TF_IMG},\"${TF_CMD}\",'basic.tfvars']"
+    - "bundle exec rake destroy['basic',${TF_IMG},\"${TF_CMD}\",'basic.tfvars']"

--- a/examples/basic.tfvars
+++ b/examples/basic.tfvars
@@ -1,0 +1,2 @@
+stack_item_fullname = "Basic AWS VPC deployment example"
+stack_item_label    = "exmpl-bsc"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -49,7 +49,6 @@ module "vpc_vpg" {
 
 ## Configures routing
 resource "aws_route" "dmz-to-igw" {
-  count                  = "${length(split(",",lookup(var.az,var.region)))}"
   route_table_id         = "${module.vpc_base.rt_dmz_id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${module.vpc_base.igw_id}"
@@ -57,7 +56,7 @@ resource "aws_route" "dmz-to-igw" {
 
 resource "aws_route" "lan-to-nat" {
   count                  = "${length(split(",",lookup(var.az,var.region))) * var.lans_per_az}"
-  route_table_id         = "${element(split(module.vpc_az.rt_lan_id),count.index)}"
+  route_table_id         = "${element(split(",",module.vpc_az.rt_lan_id),count.index)}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(split(module.vpc_az.nat_id),count.index)}"
+  nat_gateway_id         = "${element(split(",",module.vpc_az.nat_id),count.index)}"
 }

--- a/examples/full_stack.tfvars
+++ b/examples/full_stack.tfvars
@@ -1,0 +1,4 @@
+domain_name         = "unif.io"
+stack_item_fullname = "Full Terraform AWS VPC deployment example"
+stack_item_label    = "exmpl-fs"
+vpc_cidr            = "172.16.0.0/21"


### PR DESCRIPTION
Updated CI build to verify modules against the latest version of Terraform and using the container we typically deploy into CI systems.

Also added a first pass at automated UAT. The build now spins up the basic VPC example and tears it down.
