### PR TITLE
#32 Support aws provider instance_tenancy value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 * full ipv6 support
 * vpc endpoints
 
+## 0.3.6 (Jul 11, 2018)
+
+#### BUG FIXES:
+* Resolved [issue](https://github.com/unifio/terraform-aws-vpc/issues/32) caused by [terraform-provider-aws v1.25.0](https://github.com/terraform-providers/terraform-provider-aws/issues/2514). Addressed by adding a default `instance_tenancy` when one isn't supplied using a local variable.
+
 ## 0.3.5 (March 11, 2018)
 
 #### IMPROVEMENTS / NEW FEATURES:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Name | Type | Required | Description
 `enable_dns` | string | Default: `true` | Specifies whether DNS resolution is supported for the VPC.
 `enable_hostnames` | string | Default: `true` | Specifies whether the instances launched in the VPC get DNS hostnames.
 `flow_log_traffic_type` | string | Default: `ALL` | The type of traffic to capture. Valid values: ACCEPT,REJECT,ALL.
-`instance_tenancy` | string | Default: `default` | The allowed tenancy of instances launched into the VPC. Only other option at this time is `dedicated`, which will force any instance launched into the VPC to be dedicated, regardless of the tenancy option specified when the instance is launched.
+`instance_tenancy` | string | Default: `default` | The allowed tenancy of instances launched into the VPC. Other options at this time are `dedicated` and `host`. These will both force any instance launched into the VPC to be dedicated, regardless of the tenancy option specified when the instance is launched. See [EC2 Dedicated Instance Doc](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) for more information.
 `stack_item_label` | string | Default: `qckstrt` | Short form identifier for this stack. This value is used to create the "Name" tag for resources created by this stack item, and also serves as a unique key for re-use.
 `stack_item_fullname` | string | Default: `VPC Quick Start` | Long form descriptive name for this stack item. This value is used to create the "application" tag for resources created by this stack item.
 `vpc_cidr` | string | Default: `172.16.0.0/21` | The CIDR block you want the VPC to cover.

--- a/base/main.tf
+++ b/base/main.tf
@@ -5,10 +5,15 @@ terraform {
   required_version = "> 0.11.0"
 }
 
+## Set default instance tennancy if not provided
+locals {
+  default_instance_tenancy = "${length(var.instance_tenancy) >= 1 ? "${var.instance_tenancy}" : "default"}"
+}
+
 ## Provisions Virtual Private Cloud (VPC)
 resource "aws_vpc" "vpc" {
   cidr_block                       = "${var.vpc_cidr}"
-  instance_tenancy                 = "${var.instance_tenancy}"
+  instance_tenancy                 = "${local.default_instance_tenancy}"
   enable_dns_support               = "${var.enable_dns}"
   enable_dns_hostnames             = "${var.enable_hostnames}"
   enable_classiclink               = "${var.enable_classiclink}"


### PR DESCRIPTION
#### Description
[Issue #32](https://github.com/unifio/terraform-aws-vpc/issues/32)

* Instance tenancy now uses validation.StringInSlice so a value must be supplied.
* Created a local value to store the instance_tenancy if a value is supplied otherwise sets it to the default value to avoid supplying an empty value which is no longer supported.
* Updated README and CHANGELOG to prepare for version update. 