### PR TITLE
Fix deprecation warning for log_group_name

### DIFF
--- a/base/main.tf
+++ b/base/main.tf
@@ -94,8 +94,8 @@ resource "aws_iam_role_policy" "flow_log_role_policies" {
 }
 
 resource "aws_flow_log" "flow_log" {
-  log_group_name = "${aws_cloudwatch_log_group.flow_log_group.name}"
-  iam_role_arn   = "${aws_iam_role.flow_log_role.arn}"
-  vpc_id         = "${aws_vpc.vpc.id}"
-  traffic_type   = "${var.flow_log_traffic_type}"
+  log_destination = "${aws_cloudwatch_log_group.flow_log_group.name}"
+  iam_role_arn    = "${aws_iam_role.flow_log_role.arn}"
+  vpc_id          = "${aws_vpc.vpc.id}"
+  traffic_type    = "${var.flow_log_traffic_type}"
 }


### PR DESCRIPTION
Please see https://www.terraform.io/docs/providers/aws/r/flow_log.html#log_group_name

This should fix the warning:

`Warning: module.vpc_base.aws_flow_log.flow_log: "log_group_name": [DEPRECATED] use 'log_destination' argument instead`