### PR TITLE
Specify required argument to aws_ami resource

### DIFF
--- a/az/main.tf
+++ b/az/main.tf
@@ -82,7 +82,7 @@ resource "aws_route_table_association" "rta_dmz" {
 data "aws_ami" "nat_ami" {
   most_recent = true
 
-  owner = ["amazon"]
+  owners = ["amazon"]
 
   filter {
     name   = "architecture"

--- a/az/main.tf
+++ b/az/main.tf
@@ -82,6 +82,8 @@ resource "aws_route_table_association" "rta_dmz" {
 data "aws_ami" "nat_ami" {
   most_recent = true
 
+  owner = ["amazon"]
+
   filter {
     name   = "architecture"
     values = ["x86_64"]
@@ -90,11 +92,6 @@ data "aws_ami" "nat_ami" {
   filter {
     name   = "name"
     values = ["amzn-ami-vpc-nat*"]
-  }
-
-  filter {
-    name   = "owner-alias"
-    values = ["amazon"]
   }
 
   filter {


### PR DESCRIPTION
The owner argument is required for the aws_ami data source.  This pull request replaces the "owner-alias" filter with an explicit declaration of the owner argument.

This should fix the following error:
```
Error: module.vpc_az.data.aws_ami.nat_ami: "owners": required field is not set
```