### PR TITLE
Allow subnet specific tags

### DIFF
--- a/az/main.tf
+++ b/az/main.tf
@@ -67,7 +67,7 @@ resource "aws_subnet" "dmz" {
   map_public_ip_on_launch = "${var.enable_dmz_public_ips}"
   vpc_id                  = "${var.vpc_id}"
 
-  tags = "${merge(local.default_subnet_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-dmz-${count.index}"))}"
+  tags = "${merge(local.default_subnet_tags, var.additional_dmz_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-dmz-${count.index}"))}"
 }
 
 ### Associates subnet with routing table
@@ -188,7 +188,7 @@ resource "aws_subnet" "lan" {
   cidr_block = "${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier),count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
   vpc_id     = "${var.vpc_id}"
 
-  tags = "${merge(local.default_subnet_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-lan-${count.index}"))}"
+  tags = "${merge(local.default_subnet_tags, var.additional_lan_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-lan-${count.index}"))}"
 }
 
 ### Provisions routing table

--- a/az/variables.tf
+++ b/az/variables.tf
@@ -13,6 +13,18 @@ variable "stack_item_label" {
   default     = "qckstrt"
 }
 
+variable "additional_dmz_tags" {
+  type        = "map"
+  description = "Additional tags to apply at the dmz subnet level, if any"
+  default     = {}
+}
+
+variable "additional_lan_tags" {
+  type        = "map"
+  description = "Additional tags to apply at the lan subnet level, if any"
+  default     = {}
+}
+
 variable "additional_subnet_tags" {
   type        = "map"
   description = "Additional tags to apply at the subnet level, if any"


### PR DESCRIPTION
This pull request adds a couple more variables (`additional_dmz_tags` & `additional_lan_tags`) to the az terraform module.  By adding these additional tags, we can differentiate between dmz and lan subnets.

An example use case for this feature is; suppose we want to create a VPC for an AWS EKS cluster. Defining these additional tags allows one to control where Elastic Load Balancers are provisioned. See [Cluster VPC considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html#vpc-subnet-tagging) in the AWS documentation.

Here is an example of possible data values:
```
terraform::vpc::vars:
  additional_dmz_tags: { "kubernetes.io/role/elb": "1" }
  additional_lan_tags: { "kubernetes.io/role/internal-elb": "1" }
  additional_subnet_tags: { "kubernetes.io/cluster/%{hiera('env_label')}": "shared" }
```